### PR TITLE
Remove check if size_t >= 0

### DIFF
--- a/src/el/value.cc
+++ b/src/el/value.cc
@@ -85,7 +85,7 @@ Value* ValueArray::AddInteger(int32_t value) {
 }
 
 Value* ValueArray::at(size_t i) const {
-  if (i >= 0 && i < list_.size()) {
+  if (i < list_.size()) {
     return list_[i].get();
   }
   return nullptr;


### PR DESCRIPTION
size_t is unsigned so checking if it's greater than or equal to 0 seems pointless as it will always be true.
