### PR TITLE
Build testbed only on Windows.

### DIFF
--- a/premake5.lua
+++ b/premake5.lua
@@ -14,4 +14,6 @@ project("elemental-forms")
   })
   recursive_platform_files("src/")
 
-include("testbed")
+if os.is("windows") then
+  include("testbed")
+end


### PR DESCRIPTION
Do not build testbed under any other OS than Windows.

Also the testbed project has mixed C++ and C files, which does not build
under the current Linux build framework (premake and clang).
