### PR TITLE
Premake: fix usage of build scripts

### DIFF
--- a/testbed/premake5.lua
+++ b/testbed/premake5.lua
@@ -1,5 +1,5 @@
 project_root = ".."
-include(project_root.."/build_tools")
+dofile(project_root.."/build_tools/scripts/platform_files.lua")
 
 group("samples")
 project("elemental-forms-testbed")


### PR DESCRIPTION
There is an issue with the current usage of the premake project files.
The 'include' function provided by Premake will ignore the included
file if it was already included once before.

Unfortunately, the 'platform_files.lua' script needs to be 'run' in each
folder in order to properly filter the files. As suggested in the Premake
wiki page for 'include', use 'dofile' Lua function instead to use the
script.

No problem was observed explicitly, this is a preventive fix for the
same kind of issue that was seen in the Xenia project (see benvanik/xenia#471)
